### PR TITLE
Call dust.onLoad with the context if it accepts more than 2 arguments

### DIFF
--- a/lib/dust.js
+++ b/lib/dust.js
@@ -112,7 +112,16 @@
     return stream;
   };
 
-  function getTemplate(nameOrTemplate) {
+  /**
+   * Extracts a template function (body_0) from whatever is passed.
+   * @param nameOrTemplate {*} Could be:
+   *   - the name of a template to load from cache
+   *   - a CommonJS-compiled template (a function with a `template` property)
+   *   - a template function
+   * @param loadFromCache {Boolean} if false, don't look in the cache
+   * @return {Function} a template function, if found
+   */
+  function getTemplate(nameOrTemplate, loadFromCache/*=true*/) {
     if(!nameOrTemplate) {
       return;
     }
@@ -123,6 +132,9 @@
     if(dust.isTemplateFn(nameOrTemplate)) {
       // Template functions passed directly
       return nameOrTemplate;
+    }
+    if(loadFromCache === false) {
+      return;
     }
     // Try loading a template with this name from cache
     return dust.cache[nameOrTemplate];
@@ -137,19 +149,18 @@
       dust.cache = {};
     }
 
-    var tmpl = getTemplate(nameOrTemplate);
+    var template = getTemplate(nameOrTemplate);
 
-    if (tmpl) {
-      return tmpl(chunk, Context.wrap(context, tmpl.templateName));
+    if (template) {
+      return template(chunk, Context.wrap(context, template.templateName));
     } else {
       if (dust.onLoad) {
         return chunk.map(function(chunk) {
           // Alias just so it's easier to read that this would always be a name
           var name = nameOrTemplate;
-          // Four possible scenarios for a successful callback:
+          // Three possible scenarios for a successful callback:
           //   - `require(nameOrTemplate)(dust); cb()`
           //   - `src = readFile('src.dust'); cb(null, src)`
-          //   - `cb(null, 'nameOfSomeOtherTemplate')`
           //   - `compiledTemplate = require(nameOrTemplate)(dust); cb(null, compiledTemplate)`
           dust.onLoad(name, function(err, srcOrTemplate) {
             var template;
@@ -157,7 +168,7 @@
               return chunk.setError(err);
             }
             // Prefer a template that is passed via callback over the cached version.
-            template = getTemplate(srcOrTemplate) || getTemplate(name);
+            template = getTemplate(srcOrTemplate, false) || getTemplate(name);
             if (!template) {
               // It's a template string, compile it and register under `name`
               dust.loadSource(dust.compile(srcOrTemplate, name));

--- a/lib/dust.js
+++ b/lib/dust.js
@@ -157,17 +157,17 @@
         return chunk.map(function(chunk) {
           // Alias just so it's easier to read that this would always be a name
           var name = nameOrTemplate;
+
           // Three possible scenarios for a successful callback:
           //   - `require(nameOrTemplate)(dust); cb()`
           //   - `src = readFile('src.dust'); cb(null, src)`
           //   - `compiledTemplate = require(nameOrTemplate)(dust); cb(null, compiledTemplate)`
-          dust.onLoad(name, function(err, srcOrTemplate) {
-            var template;
+          var args = [name, function(err, srcOrTemplate) {
             if (err) {
               return chunk.setError(err);
             }
             // Prefer a template that is passed via callback over the cached version.
-            template = getTemplate(srcOrTemplate, false) || getTemplate(name);
+            var template = getTemplate(srcOrTemplate, false) || getTemplate(name);
             if (!template) {
               // It's a template string, compile it and register under `name`
               if(dust.compile) {
@@ -178,7 +178,13 @@
               }
             }
             template(chunk, Context.wrap(context, template.templateName)).end();
-          });
+          }];
+
+          if (dust.onLoad.length > 2) {
+            args.splice(1, 0, Context.wrap(context, name));
+          }
+
+          dust.onLoad.apply(dust, args);
         });
       }
       return chunk.setError(new Error('Template Not Found: ' + nameOrTemplate));

--- a/lib/dust.js
+++ b/lib/dust.js
@@ -113,10 +113,14 @@
   };
 
   function getTemplate(nameOrTemplate) {
+    if(!nameOrTemplate) {
+      return;
+    }
     if(typeof nameOrTemplate === 'function' && nameOrTemplate.template) {
       // Sugar away CommonJS module templates
       return nameOrTemplate.template;
-    } else if(dust.isTemplateFn(nameOrTemplate)) {
+    }
+    if(dust.isTemplateFn(nameOrTemplate)) {
       // Template functions passed directly
       return nameOrTemplate;
     }
@@ -142,23 +146,24 @@
         return chunk.map(function(chunk) {
           // Alias just so it's easier to read that this would always be a name
           var name = nameOrTemplate;
-          // Three possible scenarios for a successful callback:
+          // Four possible scenarios for a successful callback:
           //   - `require(nameOrTemplate)(dust); cb()`
           //   - `src = readFile('src.dust'); cb(null, src)`
+          //   - `cb(null, 'nameOfSomeOtherTemplate')`
           //   - `compiledTemplate = require(nameOrTemplate)(dust); cb(null, compiledTemplate)`
           dust.onLoad(name, function(err, srcOrTemplate) {
             var template;
             if (err) {
               return chunk.setError(err);
             }
-            // Prefer a template that is directly passed in over the cached version.
+            // Prefer a template that is passed via callback over the cached version.
             template = getTemplate(srcOrTemplate) || getTemplate(name);
             if (!template) {
               // It's a template string, compile it and register under `name`
               dust.loadSource(dust.compile(srcOrTemplate, name));
               template = dust.cache[name];
             }
-            template(chunk, Context.wrap(context, name)).end();
+            template(chunk, Context.wrap(context, template.templateName)).end();
           });
         });
       }

--- a/lib/dust.js
+++ b/lib/dust.js
@@ -133,11 +133,10 @@
       // Template functions passed directly
       return nameOrTemplate;
     }
-    if(loadFromCache === false) {
-      return;
+    if(loadFromCache !== false) {
+      // Try loading a template with this name from cache
+      return dust.cache[nameOrTemplate];
     }
-    // Try loading a template with this name from cache
-    return dust.cache[nameOrTemplate];
   }
 
   function load(nameOrTemplate, chunk, context) {

--- a/lib/dust.js
+++ b/lib/dust.js
@@ -171,8 +171,12 @@
             template = getTemplate(srcOrTemplate, false) || getTemplate(name);
             if (!template) {
               // It's a template string, compile it and register under `name`
-              dust.loadSource(dust.compile(srcOrTemplate, name));
-              template = dust.cache[name];
+              if(dust.compile) {
+                dust.loadSource(dust.compile(srcOrTemplate, name));
+                template = dust.cache[name];
+              } else {
+                return chunk.setError(new Error('Dust compiler not available'));
+              }
             }
             template(chunk, Context.wrap(context, template.templateName)).end();
           });

--- a/lib/dust.js
+++ b/lib/dust.js
@@ -112,6 +112,18 @@
     return stream;
   };
 
+  function getTemplate(nameOrTemplate) {
+    if(typeof nameOrTemplate === 'function' && nameOrTemplate.template) {
+      // Sugar away CommonJS module templates
+      return nameOrTemplate.template;
+    } else if(dust.isTemplateFn(nameOrTemplate)) {
+      // Template functions passed directly
+      return nameOrTemplate;
+    }
+    // Try loading a template with this name from cache
+    return dust.cache[nameOrTemplate];
+  }
+
   function load(nameOrTemplate, chunk, context) {
     if(!nameOrTemplate) {
       return chunk.setError(new Error('No template or template name provided to render'));
@@ -121,31 +133,32 @@
       dust.cache = {};
     }
 
-    var tmpl;
-    if(typeof nameOrTemplate === 'function' && nameOrTemplate.template) {
-      // Sugar away CommonJS module templates
-      tmpl = nameOrTemplate.template;
-    } else if(dust.isTemplateFn(nameOrTemplate)) {
-      // Template functions passed directly
-      tmpl = nameOrTemplate;
-    } else {
-      // Load a template with this name from cache
-      tmpl = dust.cache[nameOrTemplate];
-    }
+    var tmpl = getTemplate(nameOrTemplate);
 
     if (tmpl) {
       return tmpl(chunk, Context.wrap(context, tmpl.templateName));
     } else {
       if (dust.onLoad) {
         return chunk.map(function(chunk) {
-          dust.onLoad(nameOrTemplate, function(err, src) {
+          // Alias just so it's easier to read that this would always be a name
+          var name = nameOrTemplate;
+          // Three possible scenarios for a successful callback:
+          //   - `require(nameOrTemplate)(dust); cb()`
+          //   - `src = readFile('src.dust'); cb(null, src)`
+          //   - `compiledTemplate = require(nameOrTemplate)(dust); cb(null, compiledTemplate)`
+          dust.onLoad(name, function(err, srcOrTemplate) {
+            var template;
             if (err) {
               return chunk.setError(err);
             }
-            if (!dust.cache[nameOrTemplate]) {
-              dust.loadSource(dust.compile(src, nameOrTemplate));
+            // Prefer a template that is directly passed in over the cached version.
+            template = getTemplate(srcOrTemplate) || getTemplate(name);
+            if (!template) {
+              // It's a template string, compile it and register under `name`
+              dust.loadSource(dust.compile(srcOrTemplate, name));
+              template = dust.cache[name];
             }
-            dust.cache[nameOrTemplate](chunk, Context.wrap(context, nameOrTemplate)).end();
+            template(chunk, Context.wrap(context, name)).end();
           });
         });
       }

--- a/lib/dust.js
+++ b/lib/dust.js
@@ -144,7 +144,7 @@
       return chunk.setError(new Error('No template or template name provided to render'));
     }
 
-    if(!dust.config.cache) {
+    if(dust.config.cache === false) {
       dust.cache = {};
     }
 

--- a/test/core.js
+++ b/test/core.js
@@ -37,6 +37,25 @@ exports.coreSetup = function(suite, auto) {
       unit.pass();
     });
   });
+
+  suite.test('onLoad receives a compiled template', function() {
+    var unit = this;
+    dust.onLoad = function(name, cb) {
+      var tmpl = dust.loadSource(dust.compile('Loaded: ' + name));
+      cb(null, tmpl);
+    };
+    dust.render("onLoad", {}, function(err, out) {
+      try {
+        unit.ifError(err);
+        unit.equals(out, "Loaded: onLoad");
+      } catch(err) {
+        unit.fail(err);
+        return;
+      }
+      unit.pass();
+    });  
+  })
+
   suite.test("disable cache", function() {
     var unit = this,
         template = "Version 1",

--- a/test/core.js
+++ b/test/core.js
@@ -80,26 +80,6 @@ exports.coreSetup = function(suite, auto) {
     });
   });
 
-  suite.test('onLoad that returns a different template name', function() {
-    var unit = this;
-    dust.cache.onLoad = null;
-    dust.onLoad = function(name, cb) {
-      dust.loadSource(dust.compile('Loaded: ' + name + ', template name {templateName}', 'foobar'));
-      cb(null, 'foobar');
-    };
-    dust.render("onLoad", { templateName: function(chunk, context) { return context.getTemplateName(); } }, function(err, out) {
-      try {
-        unit.ifError(err);
-        unit.equals(out, "Loaded: onLoad, template name foobar");
-        unit.equals(dust.cache.onLoad, null);
-      } catch(err) {
-        unit.fail(err);
-        return;
-      }
-      unit.pass();
-    });
-  })
-
   suite.test("disable cache", function() {
     var unit = this,
         template = "Version 1",

--- a/test/jasmine-test/spec/cjsSpec.js
+++ b/test/jasmine-test/spec/cjsSpec.js
@@ -16,6 +16,7 @@ describe('CommonJS template', function() {
 
   beforeEach(function() {
     tmpl = load(template);
+    dust.onLoad = undefined;
   });
 
   it('can be invoked to render', function() {
@@ -45,14 +46,30 @@ describe('CommonJS template', function() {
   });
 
   it('has a template property that can be passed to dust.render', function() {
-    expect(tmpl.template.templateName).toEqual(templateName);
     dust.render(tmpl.template, context, function(err, out) {
       expect(out).toEqual(rendered);
     });
   });
 
   it('has a name that can be passed to dust.render', function() {
-    dust.render(templateName, context, function(err, out) {
+    dust.render(tmpl.template.templateName, context, function(err, out) {
+      expect(out).toEqual(rendered);
+    });
+  });
+
+  it('can be passed to dust.render even if it is anonymous', function() {
+    tmpl = eval(dust.compile("Hello anonymous {world}!"))(dust);
+    dust.render(tmpl, context, function(err, out) {
+      expect(out).toEqual("Hello anonymous world!");
+    });
+  });
+
+  it('can be loaded via dust.onLoad', function() {
+    dust.onLoad = function(nameOrTemplate, callback) {
+      // Haha, you asked for some random template but we will always give you ours instead
+      callback(null, tmpl);
+    };
+    dust.render('foobar', context, function(err, out) {
       expect(out).toEqual(rendered);
     });
   });


### PR DESCRIPTION
Just for discussion -- this is equivalent to what has served our needs very well in adaro over the last couple years. We've surprisingly not run into any namespace weirdness.

The details around template names are fiddly. In some cases, I've wrapped templates and blocks at load time so that blocks can know what template the came from. There's an opportunity to make some things like that better here.
